### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ pnpm dev
 
 ## Star History
 
-<a href="https://www.star-history.com/#subhamBharadwaz/scribbly&Date">
+<a href="https://star-history.dera.page/#subhamBharadwaz/scribbly&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=subhamBharadwaz/scribbly&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=subhamBharadwaz/scribbly&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=subhamBharadwaz/scribbly&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=subhamBharadwaz/scribbly&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=subhamBharadwaz/scribbly&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=subhamBharadwaz/scribbly&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken. This change points it to a working alternative that serves the chart without needing a GitHub API token, so the chart displays again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History links and chart images to use the current hosting endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->